### PR TITLE
test: tweak timeout and other details for lighthouse test

### DIFF
--- a/lighthouse.test.js
+++ b/lighthouse.test.js
@@ -6,19 +6,17 @@ const net = require('net')
 const checkConnection = (host, port, timeout = 10000) => {
   return new Promise((resolve, reject) => {
     const timer = setTimeout(() => {
-      // eslint-disable-next-line prefer-promise-reject-errors
-      reject('timeout')
-      // eslint-disable-next-line no-use-before-define
       socket.end()
+      return reject('timeout')
     }, timeout)
     const socket = net.createConnection(port, host, () => {
       clearTimeout(timer)
-      resolve(true)
       socket.end()
+      return resolve(true)
     })
     socket.on('error', err => {
       clearTimeout(timer)
-      reject(err)
+      return reject(err)
     })
   })
 }

--- a/lighthouse.test.js
+++ b/lighthouse.test.js
@@ -63,5 +63,4 @@ test('performance audit', async () => {
     expect(scores['best-practices']).toBeGreaterThanOrEqual(0.93)
     expect(scores.seo).toBe(1)
   }
-  return
 }, 30000)

--- a/lighthouse.test.js
+++ b/lighthouse.test.js
@@ -2,7 +2,6 @@ const lighthouse = require('lighthouse')
 const chromeLauncher = require('chrome-launcher')
 const Table = require('cli-table')
 const net = require('net')
-const Promise = require('bluebird')
 
 const checkConnection = (host, port, timeout = 10000) => {
   return new Promise((resolve, reject) => {

--- a/lighthouse.test.js
+++ b/lighthouse.test.js
@@ -1,8 +1,30 @@
-const lighthouse = require('lighthouse');
-const chromeLauncher = require('chrome-launcher');
+const lighthouse = require('lighthouse')
+const chromeLauncher = require('chrome-launcher')
 const Table = require('cli-table')
+const net = require('net')
+const Promise = require('bluebird')
 
-let table = new Table()
+const checkConnection = (host, port, timeout = 10000) => {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      // eslint-disable-next-line prefer-promise-reject-errors
+      reject('timeout')
+      // eslint-disable-next-line no-use-before-define
+      socket.end()
+    }, timeout)
+    const socket = net.createConnection(port, host, () => {
+      clearTimeout(timer)
+      resolve(true)
+      socket.end()
+    })
+    socket.on('error', err => {
+      clearTimeout(timer)
+      reject(err)
+    })
+  })
+}
+
+const table = new Table()
 
 const output = scores => {
   Object.keys(scores).forEach(category => {
@@ -12,26 +34,37 @@ const output = scores => {
 }
 
 function launchChromeAndRunLighthouse(url, opts = {}, config = null) {
-  return chromeLauncher.launch({chromeFlags: opts.chromeFlags}).then(chrome => {
-    opts.port = chrome.port;
-    return lighthouse(url, opts, config).then(results => {
-      return chrome.kill().then(() => results)
-    });
-  });
+  return chromeLauncher
+    .launch({ chromeFlags: opts.chromeFlags })
+    .then(chrome => {
+      opts.port = chrome.port
+      return lighthouse(url, opts, config).then(results => {
+        return chrome.kill().then(() => results)
+      })
+    })
 }
 
 test('performance audit', async () => {
-  const { lhr } = await launchChromeAndRunLighthouse('http://localhost:9000')
-  
-  const scores = Object.keys(lhr.categories).reduce((merged, category) => {
-    merged[category] = lhr.categories[category].score
-    return merged
-  }, {})
+  const serverIsAlive = await checkConnection('localhost', 9000).catch(err => {
+    console.warn(
+      'Performance not tested due to server not being available',
+      err
+    )
+  })
+  if (serverIsAlive) {
+    const { lhr } = await launchChromeAndRunLighthouse('http://localhost:9000')
 
-  console.log(output(scores))
+    const scores = Object.keys(lhr.categories).reduce((merged, category) => {
+      merged[category] = lhr.categories[category].score
+      return merged
+    }, {})
 
-  expect(scores.performance).toBe(1)
-  expect(scores.accessibility).toBe(1)
-  expect(scores['best-practices']).toBeGreaterThanOrEqual(0.93)
-  expect(scores.seo).toBe(1)
-})
+    console.log(output(scores))
+
+    expect(scores.performance).toBe(1)
+    expect(scores.accessibility).toBe(1)
+    expect(scores['best-practices']).toBeGreaterThanOrEqual(0.93)
+    expect(scores.seo).toBe(1)
+  }
+  return
+}, 30000)


### PR DESCRIPTION
- Added a Jest test longer time-out default is too short for some cases and some slower machines
- Added conditional testing to ensure the test only runs when the server is available.